### PR TITLE
[model_serving] fix: change base image from slim to buster

### DIFF
--- a/model_serving/deployment/Dockerfile
+++ b/model_serving/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim AS build
+FROM python:3.8-buster AS build
 
 RUN apt-get update
 
@@ -8,7 +8,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY deployment/requirements.txt .
 RUN pip install -r requirements.txt
 
-FROM python:3.8-slim
+FROM python:3.8-buster
 
 COPY --from=build /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"


### PR DESCRIPTION
## Environment
OS: MacOS Silicon M1
Docker version: 20.10.17

## Behaviour
<img width="675" alt="image" src="https://user-images.githubusercontent.com/22145541/198355715-52b81042-67a6-411c-9e59-2247fb6c0f18.png">

## Proposed solution
Change base image from **slim** to **buster** with installed gcc packages
