### PR TITLE
fix: Remove # character in the agent declaration line.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent any # 
+    agent any
 
     stages {
         stage('Build') {


### PR DESCRIPTION
Details:
Triggering Jenkins pipeline from the old Jenkinsfile causes "unexpected char: '#' " error.